### PR TITLE
Change allocate Type to AllocateAddress

### DIFF
--- a/src/bootloader/src/loader.c
+++ b/src/bootloader/src/loader.c
@@ -58,7 +58,7 @@ EFI_STATUS load_segment(IN EFI_FILE* const kernel_img_file,
 	#endif
 
 	status = uefi_call_wrapper(gBS->AllocatePages, 4,
-		AllocateAnyPages, EfiLoaderData, segment_page_count,
+		AllocateAddress, EfiLoaderData, segment_page_count,
 		(EFI_PHYSICAL_ADDRESS*)segment_virtual_address);
 	if(EFI_ERROR(status)) {
 		debug_print_line(L"Error: Error allocating pages for ELF segment: %s\n",


### PR DESCRIPTION
The allocation Type should be AllocateAddress and not AllocateAnyPages. If the allocation type is AllocateAnyPages, it will ignore the segment_virtual_address and the pages will get allocated randomly to memory.

Here is the difference from the UEFI spec (page 166):

_Allocation requests of Type **AllocateAnyPages** allocate any available range of pages that satisfies the
request. On input, the address pointed to by **Memory** is ignored._

_Allocation requests of Type **AllocateAddress** allocate pages at the address pointed to by **Memory** on
input._ 

